### PR TITLE
Complete the WASM implementation of `storyboard-warp`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     dokka(project(":storyboard"))
     dokka(project(":storyboard-easel"))
     dokka(project(":storyboard-text"))
+    dokka(project(":storyboard-warp"))
 }
 
 allprojects {

--- a/examples/basic/build.gradle.kts
+++ b/examples/basic/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
                 implementation(project(":storyboard-easel"))
                 implementation(project(":storyboard-layout"))
                 implementation(project(":storyboard-text"))
+                implementation(project(":storyboard-warp"))
 
                 implementation(project(":examples:shared"))
 

--- a/examples/basic/src/commonMain/kotlin/WarpScene.kt
+++ b/examples/basic/src/commonMain/kotlin/WarpScene.kt
@@ -1,0 +1,113 @@
+import androidx.compose.material.Text
+import dev.bnorm.storyboard.BasicCode
+import dev.bnorm.storyboard.Kotlin
+import dev.bnorm.storyboard.StoryboardBuilder
+import dev.bnorm.storyboard.ui.warp
+import org.intellij.lang.annotations.Language
+
+@Language("kotlin")
+val TRACING_SLIDES = listOf(
+    """
+      import androidx.tracing.Tracer
+      import androidx.tracing.DelicateTracingApi
+      import androidx.tracing.wire.TraceDriver
+      import androidx.tracing.wire.TraceSink
+      import java.io.File
+
+      fun main() {
+          
+      }
+    """.trimIndent(),
+
+    """
+      import androidx.tracing.Tracer
+      import androidx.tracing.DelicateTracingApi
+      import androidx.tracing.wire.TraceDriver
+      import androidx.tracing.wire.TraceSink
+      import java.io.File
+
+      fun main() {
+          // Create the TraceSink, and the `TraceDriver`
+
+          // Register the tracer
+
+          // Call driver.close() as a result of the process shutdown hook.
+      }
+    """.trimIndent(),
+
+
+    """
+      import androidx.tracing.Tracer
+      import androidx.tracing.DelicateTracingApi
+      import androidx.tracing.wire.TraceDriver
+      import androidx.tracing.wire.TraceSink
+      import java.io.File
+
+      fun main() {
+          // Create the TraceSink, and the `TraceDriver`
+          val outputDirectory = File("/tmp/perfetto")
+          val sink = TraceSink(directory = outputDirectory)
+          val driver = TraceDriver(sink = sink, isEnabled = true)
+
+          // Register the tracer
+
+          // Call driver.close() as a result of the process shutdown hook.
+      }
+    """.trimIndent(),
+
+    """
+      import androidx.tracing.Tracer
+      import androidx.tracing.DelicateTracingApi
+      import androidx.tracing.wire.TraceDriver
+      import androidx.tracing.wire.TraceSink
+      import java.io.File
+
+      fun main() {
+          // Create the TraceSink, and the `TraceDriver`
+          val outputDirectory = File("/tmp/perfetto")
+          val sink = TraceSink(directory = outputDirectory)
+          val driver = TraceDriver(sink = sink, isEnabled = true)
+
+          // Register the tracer
+          @OptIn(DelicateTracingApi::class)
+          Tracer.setGlobalTracer(driver.tracer)
+
+          // Call driver.close() as a result of the process shutdown hook.
+          // ...
+      }
+    """.trimIndent(),
+
+    """
+      import androidx.tracing.Tracer
+      import androidx.tracing.DelicateTracingApi
+      import androidx.tracing.wire.TraceDriver
+      import androidx.tracing.wire.TraceSink
+      import java.io.File
+
+      fun main() {
+          // Create the TraceSink, and the `TraceDriver`
+          val outputDirectory = File("/tmp/perfetto")
+          val sink = TraceSink(directory = outputDirectory)
+          val driver = TraceDriver(sink = sink, isEnabled = true)
+
+          // Register the tracer
+          @OptIn(DelicateTracingApi::class)
+          Tracer.setGlobalTracer(driver.tracer)
+
+          // Call driver.close() as a result of the process shutdown hook.
+          Runtime.getRuntime().addShutdownHook(Thread {
+              driver.close()
+          })
+      }
+    """.trimIndent()
+).map { BasicCode(code = it) }
+
+
+@Suppress("FunctionName")
+fun StoryboardBuilder.WarpScene() = warp(
+    codeBlocks = TRACING_SLIDES,
+    language = Kotlin,
+    header = {
+        Text("Code Scene")
+    }
+)

--- a/examples/basic/src/commonMain/kotlin/story.kt
+++ b/examples/basic/src/commonMain/kotlin/story.kt
@@ -17,6 +17,7 @@ fun createStoryboard(): Storyboard {
         StateScene()
         AnimationScene()
         CodeScene()
+        WarpScene()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,14 @@ antlr-kotlin = "1.0.8"
 compose-jb = "1.10.1"
 kotlin = "2.3.0"
 ktor = "3.3.3"
+collection = "1.6.0"
+# TextMate parsing dependencies for JVM
+# # Eclipse T4ME + Transitive dependencies
+t4me = "0.17.3-SNAPSHOT"
+jdt-annotations = "2.4.100"
+joni = "2.2.7"
+jcodings = "1.0.64"
+annotations = "26.1.0"
 
 [plugins]
 antlr-kotlin = { id = "com.strumenta.antlr-kotlin", version.ref = "antlr-kotlin" }
@@ -15,6 +23,8 @@ kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization"
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.35.0" }
 
 [libraries]
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
 antlr-kotlin-runtime = { module = "com.strumenta:antlr-kotlin-runtime", version.ref = "antlr-kotlin" }
 compose-materialIcons = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }
 filekit-compose = { module = "io.github.vinceglb:filekit-compose", version = "0.8.8" }
@@ -26,3 +36,10 @@ ktor-client-engine-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor
 ktor-client-engine-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version = "3.0.6" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "collection" }
+# TextMate parsing dependencies for JVM
+# # Eclipse T4ME + Transitive dependencies
+eclipse-t4me-core = { module = "org.eclipse:org.eclipse.tm4e.core", version.ref = "t4me" }
+eclipse-jdt-annotations = { module = "org.eclipse.jdt:org.eclipse.jdt.annotation", version.ref = "jdt-annotations" }
+jruby-joni = { module = "org.jruby.joni:joni", version.ref = "joni" }
+jruby-jcodings = { module = "org.jruby.jcodings:jcodings", version.ref = "jcodings" }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -2,7 +2,332 @@
 # yarn lockfile v1
 
 
+"@shikijs/core@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-4.4.3.tgz#00a942fa45ad0e4146ac6dbbac32b8b704b42e3f"
+  integrity sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==
+  dependencies:
+    "@shikijs/primitive" "4.4.3"
+    "@shikijs/types" "4.4.3"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
+    hast-util-to-html "^9.0.5"
+
+"@shikijs/engine-javascript@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz#42dbdc18ec2f86003624674839a8f090cdd7cb62"
+  integrity sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==
+  dependencies:
+    "@shikijs/types" "4.4.3"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    oniguruma-to-es "^4.3.6"
+
+"@shikijs/engine-oniguruma@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz#a1754f9f42e0f35a55cda9a977599041a2ad5b07"
+  integrity sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==
+  dependencies:
+    "@shikijs/types" "4.4.3"
+    "@shikijs/vscode-textmate" "^10.0.2"
+
+"@shikijs/langs@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-4.4.3.tgz#113282396f119dbba8d3b5e86668258fa8df6e7b"
+  integrity sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==
+  dependencies:
+    "@shikijs/types" "4.4.3"
+
+"@shikijs/primitive@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/primitive/-/primitive-4.4.3.tgz#86490cea63b3e2c56b8d9163046e010258844d81"
+  integrity sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==
+  dependencies:
+    "@shikijs/types" "4.4.3"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
+
+"@shikijs/themes@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-4.4.3.tgz#8310a78261f4cf742663e07e2028df046a02bd72"
+  integrity sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==
+  dependencies:
+    "@shikijs/types" "4.4.3"
+
+"@shikijs/types@4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-4.4.3.tgz#019aff19f0cbfb21642c59f6f8432ced74e27b45"
+  integrity sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==
+  dependencies:
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
+
+"@shikijs/vscode-textmate@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz#a90ab31d0cc1dfb54c66a69e515bf624fa7b2224"
+  integrity sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
+
+"@types/hast@^3.0.0", "@types/hast@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.5.tgz#48020de4c0e63492f4ca9db42068c108f68b7f8f"
+  integrity sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==
+  dependencies:
+    "@types/unist" "*"
+
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
+
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+
+"@ungap/structured-clone@^1.0.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz#094041e1a4cb1987f038335421281ac8be390bcc"
+  integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
+
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
+
+hast-util-to-html@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+
+mdast-util-to-hast@^13.0.0:
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz#d7ff84ca499a57e2c060ae67548ad950e689a053"
+  integrity sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz#f00225f5f5a0ebc3254f96c36b6605c4b393908e"
+  integrity sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+
+oniguruma-parser@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz#e27ca446f7fcf0969662a3ab9b4f43176d62b139"
+  integrity sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==
+
+oniguruma-to-es@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz#43e640280241b0d687a314e7a641d476407a1c4d"
+  integrity sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==
+  dependencies:
+    oniguruma-parser "^0.12.2"
+    regex "^6.1.0"
+    regex-recursion "^6.0.2"
+
+property-information@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.2.0.tgz#0809b34264e995c0bfcd3227028a1e35210af80a"
+  integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
+
+regex-recursion@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-6.0.2.tgz#a0b1977a74c87f073377b938dbedfab2ea582b33"
+  integrity sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+regex-utilities@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+
+regex@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/regex/-/regex-6.1.0.tgz#d7ce98f8ee32da7497c13f6601fca2bc4a6a7803"
+  integrity sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+shiki@^4.3.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-4.4.3.tgz#31fb41c5c82435779a0b5a9b92a3b0377b061e15"
+  integrity sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==
+  dependencies:
+    "@shikijs/core" "4.4.3"
+    "@shikijs/engine-javascript" "4.4.3"
+    "@shikijs/engine-oniguruma" "4.4.3"
+    "@shikijs/langs" "4.4.3"
+    "@shikijs/themes" "4.4.3"
+    "@shikijs/types" "4.4.3"
+    "@shikijs/vscode-textmate" "^10.0.2"
+    "@types/hast" "^3.0.5"
+
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
+unist-util-is@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"
+  integrity sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz#777df7fb98652ce16b4b7cd999d0a1a40efa3a02"
+  integrity sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
+  integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
+vfile-message@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.3.tgz#87b44dddd7b70f0641c2e3ed0864ba73e2ea8df4"
+  integrity sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
+
 ws@8.18.3:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
+zwitch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,11 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
+        maven(url = uri("https://repo.eclipse.org/content/repositories/tm4e-snapshots/")) {
+            mavenContent {
+                includeGroupAndSubgroups("org.eclipse")
+            }
+        }
     }
 }
 
@@ -21,6 +26,7 @@ include(":storyboard")
 include(":storyboard-easel")
 include(":storyboard-layout")
 include(":storyboard-text")
+include(":storyboard-warp")
 
 include(":examples:basic")
 include(":examples:diagram")

--- a/storyboard-warp/build.gradle.kts
+++ b/storyboard-warp/build.gradle.kts
@@ -34,5 +34,9 @@ kotlin {
             implementation(libs.jruby.joni)
             implementation(libs.jruby.jcodings)
         }
+        wasmJsMain.dependencies {
+            implementation("org.jetbrains.kotlinx:kotlinx-browser:0.5.0")
+            implementation(npm("shiki", "^4.3.1"))
+        }
     }
 }

--- a/storyboard-warp/build.gradle.kts
+++ b/storyboard-warp/build.gradle.kts
@@ -1,0 +1,38 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.plugin.compose)
+    alias(libs.plugins.compose)
+    alias(libs.plugins.maven.publish)
+}
+
+group = "dev.bnorm.storyboard"
+
+kotlin {
+    jvm()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":storyboard"))
+            implementation(project(":storyboard-layout"))
+            api(libs.jetbrains.annotations)
+            implementation(libs.androidx.collection)
+            implementation(compose.material)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
+        jvmMain.dependencies {
+            implementation(libs.eclipse.t4me.core)
+            implementation(libs.eclipse.jdt.annotations)
+            implementation(libs.jruby.joni)
+            implementation(libs.jruby.jcodings)
+        }
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/DiffLists.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/DiffLists.kt
@@ -1,0 +1,109 @@
+package dev.bnorm.storyboard
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Represents a Scene that contains [code] among other things.
+ */
+@Immutable
+interface CodeBlock {
+    /**@return the `code` snippet in the scene. This is a multi-line [String].  */
+    fun code(): String
+}
+
+@Immutable
+data class BasicCode(val code: String) : CodeBlock {
+    override fun code(): String {
+        return code
+    }
+}
+
+@Immutable
+data class DiffContents(val rows: List<List<State>>)
+
+/**
+ * Builds a presentation for a group of slides that contain code [codeBlocks].
+ */
+fun buildDiffList(codeBlocks: List<CodeBlock>, language: Language): List<DiffContents> {
+    if (codeBlocks.isEmpty()) return emptyList()
+    val keys = Keys()
+    val diffResult = mutableListOf<DiffContents>()
+    val parsed = codeBlocks.map { snippet -> parse(code = snippet.code(), language) }
+    // Assign keys for all the tokens we see in the first slide.
+    // For every subsequent match, we propagate the existing token ids.
+    // New ids are only generated when we see new inserts.
+    parsed.first().forEach { token ->
+        keys.assignKey(token)
+    }
+    val parsedPairs = parsed.zipWithNext()
+    parsedPairs.forEachIndexed { index, (previous, current) ->
+        val states = diff(previous, current, keys)
+        if (index == 0) {
+            diffResult += beforeViewOf(states)
+            diffResult += afterViewOf(states)
+        } else {
+            // For later slides only build the incremental state
+            diffResult += afterViewOf(states)
+        }
+    }
+    return diffResult
+}
+
+
+internal fun afterViewOf(states: List<State>): DiffContents {
+    // This is the after state.
+    // This means we only show inserts and matches.
+    val filtered = states.filter { state -> state is State.Match || state is State.Insert }
+    // Group by the line
+    val rows: Map<Int, List<State>> = filtered.groupBy { state ->
+        when (state) {
+            is State.Match -> state.current.lineNumber
+            is State.Insert -> state.token.lineNumber
+            else -> throw IllegalStateException("Should never happen")
+        }
+    }
+    // Sort by the startIndex so they are ordered correctly
+    val sortedArray: Array<List<State>?> = arrayOfNulls(size = rows.size)
+    rows.forEach { (rowIdx, states) ->
+        val tokens = states.sortedBy { state ->
+            when (state) {
+                // Pick the previous state for the start index
+                is State.Match -> state.current.startIndex
+                is State.Insert -> state.token.startIndex
+                else -> throw IllegalStateException("Should never happen")
+            }
+        }
+        sortedArray[rowIdx] = tokens
+    }
+    @Suppress("UNCHECKED_CAST")
+    return DiffContents(rows = (sortedArray as Array<List<State>>).asList())
+}
+
+internal fun beforeViewOf(states: List<State>): DiffContents {
+    // This is the before state.
+    // This means we only show deletes, and matches.
+    val filtered = states.filter { state -> state is State.Match || state is State.Delete }
+    // Group by the line
+    val rows: Map<Int, List<State>> = filtered.groupBy { state ->
+        when (state) {
+            is State.Match -> state.previous.lineNumber
+            is State.Delete -> state.token.lineNumber
+            else -> throw IllegalStateException("Should never happen")
+        }
+    }
+    // Sort by the startIndex so they are ordered correctly
+    val sortedArray: Array<List<State>?> = arrayOfNulls(size = rows.size)
+    rows.forEach { (rowIdx, states) ->
+        val tokens = states.sortedBy { state ->
+            when (state) {
+                // Pick the previous state for the start index
+                is State.Match -> state.previous.startIndex
+                is State.Delete -> state.token.startIndex
+                else -> throw IllegalStateException("Should never happen")
+            }
+        }
+        sortedArray[rowIdx] = tokens
+    }
+    @Suppress("UNCHECKED_CAST")
+    return DiffContents(rows = (sortedArray as Array<List<State>>).asList())
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/DiffLists.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/DiffLists.kt
@@ -63,7 +63,7 @@ internal fun afterViewOf(states: List<State>): DiffContents {
         }
     }
     // Sort by the startIndex so they are ordered correctly
-    val sortedArray: Array<List<State>?> = arrayOfNulls(size = rows.size)
+    val sortedArray: Array<List<State>> = Array(rows.size) { emptyList() }
     rows.forEach { (rowIdx, states) ->
         val tokens = states.sortedBy { state ->
             when (state) {
@@ -75,8 +75,7 @@ internal fun afterViewOf(states: List<State>): DiffContents {
         }
         sortedArray[rowIdx] = tokens
     }
-    @Suppress("UNCHECKED_CAST")
-    return DiffContents(rows = (sortedArray as Array<List<State>>).asList())
+    return DiffContents(rows = sortedArray.asList())
 }
 
 internal fun beforeViewOf(states: List<State>): DiffContents {
@@ -92,7 +91,7 @@ internal fun beforeViewOf(states: List<State>): DiffContents {
         }
     }
     // Sort by the startIndex so they are ordered correctly
-    val sortedArray: Array<List<State>?> = arrayOfNulls(size = rows.size)
+    val sortedArray: Array<List<State>> = Array(rows.size) { emptyList() }
     rows.forEach { (rowIdx, states) ->
         val tokens = states.sortedBy { state ->
             when (state) {
@@ -104,6 +103,5 @@ internal fun beforeViewOf(states: List<State>): DiffContents {
         }
         sortedArray[rowIdx] = tokens
     }
-    @Suppress("UNCHECKED_CAST")
-    return DiffContents(rows = (sortedArray as Array<List<State>>).asList())
+    return DiffContents(rows = sortedArray.asList())
 }

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/HeckelDiff.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/HeckelDiff.kt
@@ -1,0 +1,150 @@
+package dev.bnorm.storyboard
+
+import androidx.collection.ScatterMap
+import androidx.collection.mutableScatterMapOf
+
+
+// This is an adaptation of the paper:
+// P. Heckel, A technique for isolating differences between files
+//Comm. ACM, 21, (4), 264–268 (1978).
+
+// This can help compute structural similarities between 2 text sequences.
+// Once we know this, we should be able to animate cleanly between these 2 sequences.
+
+fun diff(
+    previous: List<Token>,
+    current: List<Token>,
+    keys: Keys = Keys()
+): List<State> {
+    // Symbol tables
+    val statesP: Array<State> = Array(previous.size) { State.Empty }
+    val statesC: Array<State> = Array(current.size) { State.Empty }
+    // Frequency + Context
+    val (freqP, contextP) = frequencyAndContext(tokens = previous)
+    val (freqC, _) = frequencyAndContext(tokens = current)
+    // Phase 1: Find unique anchors such that frequency = 1 in both lists.
+    // That is a match.
+    current.forEachIndexed { index, token ->
+        val c = freqC[token]
+        val p = freqP[token]
+        val context = contextP[token]
+        if (c == 1 && p == 1 && context != null) {
+            val indexP = context.index
+            // Here we are also keeping track of the previous token.
+            // This is because we exclude the actual start and end offsets from the equals()
+            // to find high-quality anchor points.
+            val tokenP = context.token
+            val match = State.Match(
+                previous = tokenP,
+                previousIdx = indexP,
+                current = token,
+                currentIdx = index
+            )
+            statesP[match.previousIdx] = match
+            statesC[match.currentIdx] = match
+        }
+    }
+    // Phase 2: We found unique anchors.
+    // Move forward and find the ones that are matching adjacent to the ones that already matched.
+    for (index in 0 until statesC.lastIndex) {
+        val state = statesC[index]
+        val nextState = statesC[index + 1]
+        if (state is State.Match && nextState == State.Empty) {
+            val nextToken = current.getOrNull(index + 1)
+            val nextPreviousToken = previous.getOrNull(state.previousIdx + 1)
+            if (nextPreviousToken != null && nextToken == nextPreviousToken) {
+                val match = State.Match(
+                    previous = nextPreviousToken,
+                    previousIdx = state.previousIdx + 1,
+                    current = nextToken,
+                    currentIdx = index + 1,
+                )
+                statesP[match.previousIdx] = match
+                statesC[match.currentIdx] = match
+            }
+        }
+    }
+    // Phase 3: Same as Phase 2 but backwards.
+    for (index in statesC.lastIndex downTo 1) {
+        val state = statesC[index]
+        val priorState = statesC[index - 1]
+        if (state is State.Match && priorState == State.Empty) {
+            val priorToken = current.getOrNull(index - 1)
+            val priorPreviousToken = previous.getOrNull(state.previousIdx - 1)
+            if (priorToken != null && priorToken == priorPreviousToken) {
+                val match = State.Match(
+                    previous = priorPreviousToken,
+                    previousIdx = state.previousIdx - 1,
+                    current = priorToken,
+                    currentIdx = index - 1
+                )
+                statesP[match.previousIdx] = match
+                statesC[match.currentIdx] = match
+            }
+        }
+    }
+    // Phase 4: Final pass.
+    // Anything that did not match in:
+    // - statesP = Delete
+    // - statesC = Insert
+    for (i in statesP.indices) {
+        if (statesP[i] == State.Empty) {
+            statesP[i] = State.Delete(token = previous[i], index = i)
+        }
+    }
+    val size = maxOf(statesP.size, statesC.size)
+    // Keeps track of the last known deleted index in statesP
+    var deleteIdx = 0
+    // This is the final edit script.
+    val edits = ArrayList<State>(size)
+    for (i in 0 until size) {
+        if (i < statesP.size && deleteIdx <= i && statesP[i] is State.Delete) {
+            // We want to cluster all the deletes that occur next to each other.
+            var j = i
+            while (j < statesP.size && statesP[j] is State.Delete) {
+                // Add deletions to the list of edits.
+                edits += statesP[j]
+                j += 1
+            }
+            deleteIdx = j
+        }
+        if (i < statesC.size) {
+            val state = statesC[i]
+            if (state is State.Match) {
+                if (state.previous.hasKey()) {
+                    // Propagate keys for matched tokens
+                    state.current.assignKey(newKey = state.previous.key())
+                }
+            }
+            if (statesC[i] == State.Empty) {
+                // Assign a new key for newly inserted tokens
+                keys.assignKey(current[i])
+                statesC[i] = State.Insert(token = current[i], index = i)
+            }
+            edits += statesC[i]
+        }
+    }
+    return edits
+}
+
+internal data class TokenContext(val token: Token, val index: Int)
+
+internal fun frequencyAndContext(
+    tokens: List<Token>
+): Pair<ScatterMap<Token, Int>, ScatterMap<Token, TokenContext?>> {
+    val freq = mutableScatterMapOf<Token, Int>()
+    // Context for tokens whose count == 1
+    val indexes = mutableScatterMapOf<Token, TokenContext?>()
+    tokens.forEachIndexed { index, token ->
+        val count = freq.getOrDefault(token, 0)
+        if (count == 0) {
+            indexes[token] = TokenContext(token = token, index = index)
+        } else {
+            // If this is not the first time we are seeing this,
+            // We no longer care about tracking its index.
+            indexes[token] = null
+        }
+        freq[token] = count + 1
+    }
+    return freq to indexes
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Keys.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Keys.kt
@@ -1,0 +1,19 @@
+package dev.bnorm.storyboard
+
+import androidx.collection.mutableScatterMapOf
+
+class Keys {
+    /** The stable keys for all the different scenes in a story board. */
+    internal val keyMap = mutableScatterMapOf<Token, Int>()
+
+    /**
+     * Assigns a new stable `contentId` for a given [Token] instance.
+     */
+    fun assignKey(token: Token) {
+        var count = keyMap[token] ?: 0
+        count += 1
+        val key = "$token#$count"
+        token.assignKey(newKey = key)
+        keyMap[token] = count
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Language.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Language.kt
@@ -1,0 +1,40 @@
+package dev.bnorm.storyboard
+
+
+/**
+ * The canonical list of `languages` supported for parsing and rendering.
+ */
+sealed interface Language {
+    fun scopeName(): String
+}
+
+// When adding well-known languages here. Also, add the corresponding entries to the language registry for all
+// Parser implementations.
+
+/** JavaScript Object notation. */
+object Json : Language {
+    override fun scopeName(): String {
+        return "source.json"
+    }
+}
+
+/** The Kotlin programming language. */
+object Kotlin : Language {
+    override fun scopeName(): String {
+        return "source.kotlin"
+    }
+}
+
+/** XML */
+object Xml : Language {
+    override fun scopeName(): String {
+        return "text.xml"
+    }
+}
+
+/** A custom language that is [Parser] aware */
+class Custom(val parser: Parser) : Language {
+    override fun scopeName(): String {
+        return "scope.custom"
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Parser.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Parser.kt
@@ -1,0 +1,14 @@
+package dev.bnorm.storyboard
+
+
+/**
+ * A custom parser if you wanted full control on how to parse tokens.
+ */
+interface Parser {
+    /**
+     * Parses a multi-line code snippet into a sequence of [Token]s.
+     */
+    fun parse(code: String): List<Token>
+}
+
+expect fun parse(code: String, language: Language): List<Token>

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/State.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/State.kt
@@ -1,0 +1,36 @@
+package dev.bnorm.storyboard
+
+import androidx.compose.runtime.Immutable
+
+sealed class State {
+    /** Represents the initial state. */
+    object Empty : State()
+
+    /** This represents a Match. */
+    @Immutable
+    data class Match(
+        val previous: Token,
+        val previousIdx: Int,
+        val current: Token,
+        val currentIdx: Int
+    ) : State() {
+        fun content() = current.content
+    }
+
+    /** Represents an insert. */
+    @Immutable
+    data class Insert(val token: Token, val index: Int) : State()
+
+    /** Represents a deletion. */
+    @Immutable
+    data class Delete(val token: Token, val index: Int) : State()
+}
+
+fun State.content(): String {
+    return when (this) {
+        is State.Match -> content()
+        is State.Delete -> token.content
+        is State.Insert -> token.content
+        is State.Empty -> throw IllegalStateException("Should never happen")
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Token.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/Token.kt
@@ -1,0 +1,63 @@
+package dev.bnorm.storyboard
+
+/**
+ * The [Token] that will be passed to the diffing algorithm to find structural similarities.
+ *
+ * We are using a combination of the [content], and the `primary` [scope] + its [depth] to find
+ * `anchor`s.
+ */
+class Token(
+    /** The actual content of the parsed token. */
+    val content: String,
+    /** The primary scope */
+    val scope: String,
+    /** The depth of the primary scope. */
+    val depth: Int,
+    /* More context for animations and rendering. */
+    val language: Language,
+    val allScopes: List<String>,
+    val lineNumber: Int,
+    val startIndex: Int,
+    val endIndex: Int
+) {
+    /** The underlying unique key that was assigned to the token.
+     * This is guaranteed to be stable across a story board. */
+    private var key: String? = null
+
+    fun hasKey(): Boolean {
+        return key != null
+    }
+
+    fun assignKey(newKey: String) {
+        val key = key
+        check(key == null) { "Cannot override `key` for $this" }
+        this.key = newKey
+    }
+
+    fun key(): String {
+        val contentId = key
+        check(contentId != null) { "`key` was not assigned to $this" }
+        return contentId
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Token) return false
+        if (depth != other.depth) return false
+        if (content != other.content) return false
+        if (scope != other.scope) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = depth
+        result = 31 * result + content.hashCode()
+        result = 31 * result + scope.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Token(content='$content', scope='$scope', depth=$depth, lineNumber=$lineNumber, startIndex=$startIndex, endIndex=$endIndex)"
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Code.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Code.kt
@@ -1,0 +1,109 @@
+package dev.bnorm.storyboard.ui
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.sp
+import dev.bnorm.storyboard.DiffContents
+import dev.bnorm.storyboard.State
+import dev.bnorm.storyboard.Token
+import dev.bnorm.storyboard.content
+
+
+@Composable
+internal fun Code(
+    diffContents: DiffContents,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    modifier: Modifier = Modifier
+) {
+    val rows = diffContents.rows
+    Column(modifier = modifier.fillMaxSize()) {
+        rows.forEach { states: List<State> ->
+            Row {
+                states.forEach { state ->
+                    when (state) {
+                        is State.Match -> {
+                            with(receiver = sharedTransitionScope) {
+                                Text(
+                                    text = state.content(),
+                                    color = state.color(),
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = DEFAULT_FONT_SIZE.sp,
+                                    lineHeight = DEFAULT_LINE_HEIGHT.sp,
+                                    modifier = Modifier.sharedElement(
+                                        sharedContentState = rememberSharedContentState(key = state.sharedKey()),
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        boundsTransform = boundsTransform
+                                    )
+                                )
+                            }
+                        }
+
+                        is State.Delete,
+                        is State.Insert -> {
+                            val token: Token = state.token()
+                            with(sharedTransitionScope) {
+                                with(animatedVisibilityScope) {
+                                    Text(
+                                        state.content(),
+                                        color = state.color(),
+                                        fontFamily = FontFamily.Monospace,
+                                        fontSize = DEFAULT_FONT_SIZE.sp,
+                                        lineHeight = DEFAULT_LINE_HEIGHT.sp,
+                                        modifier = Modifier
+                                            .sharedElement(
+                                                sharedContentState = rememberSharedContentState(key = token.key()),
+                                                animatedVisibilityScope = animatedVisibilityScope,
+                                                boundsTransform = boundsTransform
+                                            )
+                                            .renderInSharedTransitionScopeOverlay()
+                                            .animateEnterExit(
+                                                enter = fadeIn(animationSpec = tween(durationMillis = TWEEN_DURATION_MS)),
+                                                exit = fadeOut(animationSpec = tween(durationMillis = TWEEN_DURATION_MS))
+                                            )
+                                    )
+                                }
+                            }
+                        }
+
+                        State.Empty -> {
+                            // Should never happen.
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun State.token(): Token {
+    return when (this) {
+        is State.Match -> current
+        is State.Insert -> token
+        is State.Delete -> token
+        else -> throw IllegalStateException("Should never happen")
+    }
+}
+
+internal fun State.Match.sharedKey(): String {
+    return if (previous.hasKey() && current.hasKey()) {
+        check(previous.key() == current.key()) {
+            "Content Id must match for $previous and $current"
+        }
+        current.key()
+    } else {
+        // The next best thing is to return an identifier that is automatically unique
+        // between 2 slides (but not across a deck).
+        "Match('$previousIdx' -> '$currentIdx')"
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Colors.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Colors.kt
@@ -1,0 +1,78 @@
+package dev.bnorm.storyboard.ui
+
+import androidx.compose.ui.graphics.Color
+import dev.bnorm.storyboard.State
+import dev.bnorm.storyboard.Token
+
+// Colors inspired by the IntelliJ Dark Palette
+
+// Canvas / Surface
+val Background = Color(0xFF1E1F22)
+
+// Foreground (default text, parameters, operators)
+val Foreground = Color(0xFFBCBEC4)
+
+// Keywords (fun, val, import, class, etc.)
+val Keyword = Color(0xFFCF8E6D)
+
+// String literals
+val String = Color(0xFF6AAB73)
+
+// Comments
+val Comment = Color(0xFF7A7E85)
+
+// Numbers (123, 0xFF, etc.)
+val Number = Color(0xFF2AACB8)
+
+// Constants
+val Constant = Color(0xFFCF8E6D)
+
+// Function Calls and Definitions
+val Function = Color(0xFF56A8F5)
+
+// Classes, Interfaces and Generic Types
+val Type = Color(0xFFC77DBB)
+
+// Properties and Fields
+val Property = Color(0xFFC77DBB)
+
+// Annotations (@Composable, @Preview, etc.)
+val Annotation = Color(0xFFB3AE60)
+
+// Brackets { }, Parens ( ), Commas, Dots
+val Punctuation = Color(0xFFA3A6AD)
+
+// Syntax Errors
+val Invalid = Color(0xFFFA6675)
+
+fun Token.color(): Color {
+    return when {
+        scope.contains("annotation") -> Annotation
+        scope.contains("attribute") -> Annotation
+        scope.contains("keyword") -> Keyword
+        scope.contains("storage") -> Keyword
+        scope.contains("string") -> String
+        scope.contains("comment") -> Comment
+        scope.contains("constant.language") -> Constant
+        scope.contains("constants.numeric") -> Number
+        scope.contains("constant") -> Number
+        scope.contains("function") -> Function
+        scope.contains("entity.name.type") -> Type
+        scope.contains("class") -> Type
+        scope.contains("property") -> Property
+        scope.contains("punctuation") -> Punctuation
+        scope.contains("invalid") -> Invalid
+        // Fallback to foreground color
+        else -> Foreground
+    }
+}
+
+fun State.color(): Color {
+    return when (this) {
+        // Should never really happen
+        is State.Empty -> Foreground
+        is State.Match -> current.color()
+        is State.Insert -> token.color()
+        is State.Delete -> token.color()
+    }
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Fonts.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Fonts.kt
@@ -1,0 +1,4 @@
+package dev.bnorm.storyboard.ui
+
+const val DEFAULT_FONT_SIZE = 16
+const val DEFAULT_LINE_HEIGHT = 1.5 * DEFAULT_FONT_SIZE

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Static.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Static.kt
@@ -1,0 +1,44 @@
+package dev.bnorm.storyboard.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.sp
+import dev.bnorm.storyboard.DiffContents
+import dev.bnorm.storyboard.State
+import dev.bnorm.storyboard.Token
+import dev.bnorm.storyboard.afterViewOf
+import dev.bnorm.storyboard.content
+
+@Composable
+fun Static(
+    modifier: Modifier,
+    tokens: List<Token>,
+) {
+    val rows: List<List<State>> = remember(tokens) { tokens.asDiffContents().rows }
+    Column(modifier = modifier.fillMaxSize()) {
+        rows.forEach { row ->
+            Row {
+                row.forEach { state ->
+                    Text(
+                        text = state.content(),
+                        color = state.color(),
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = DEFAULT_FONT_SIZE.sp,
+                        lineHeight = DEFAULT_LINE_HEIGHT.sp,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun List<Token>.asDiffContents(): DiffContents {
+    val inserts = mapIndexed { index, token -> State.Insert(token = token, index = index) }
+    return afterViewOf(states = inserts)
+}

--- a/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Warp.kt
+++ b/storyboard-warp/src/commonMain/kotlin/dev/bnorm/storyboard/ui/Warp.kt
@@ -1,0 +1,83 @@
+package dev.bnorm.storyboard.ui
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.bnorm.storyboard.*
+import dev.bnorm.storyboard.layout.template.Body
+import dev.bnorm.storyboard.layout.template.Header
+import dev.bnorm.storyboard.layout.template.SceneEnter
+import dev.bnorm.storyboard.layout.template.SceneExit
+
+// Milliseconds
+const val TWEEN_DURATION_MS = 200
+
+val boundsTransform = BoundsTransform { _, _ ->
+    spring(
+        dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow
+    )
+}
+
+fun dev.bnorm.storyboard.StoryboardBuilder.warp(
+    codeBlocks: List<CodeBlock>,
+    language: Language,
+    enter: SceneEnterTransition = SceneEnter(alignment = Alignment.CenterEnd),
+    exit: SceneExitTransition = SceneExit(alignment = Alignment.CenterEnd),
+    header: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    scene(
+        frameCount = codeBlocks.size,
+        enterTransition = enter,
+        exitTransition = exit
+    ) {
+        // Build the diffList once and be ready.
+        val diffList: List<DiffContents> = remember(codeBlocks, language) {
+            buildDiffList(codeBlocks, language)
+        }
+        val hScrollState = rememberScrollState()
+        val vScrollState = rememberScrollState()
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Header { header() }
+            Divider(color = MaterialTheme.colors.primary)
+            Body(modifier = Modifier.verticalScroll(vScrollState).horizontalScroll(hScrollState)) {
+                SharedTransitionLayout(modifier = modifier) {
+                    transition.AnimatedContent(
+                        transitionSpec = {
+                            fadeIn(
+                                animationSpec = tween(durationMillis = TWEEN_DURATION_MS)
+                            ).togetherWith(
+                                exit = fadeOut(
+                                    animationSpec = tween(durationMillis = TWEEN_DURATION_MS)
+                                )
+                            )
+                        }
+                    ) { frame ->
+                        val index = frame.toValue()
+                        val diffContents = diffList[index]
+                        Code(
+                            diffContents = diffContents,
+                            sharedTransitionScope = this@SharedTransitionLayout,
+                            animatedVisibilityScope = this,
+                            modifier = modifier
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/storyboard-warp/src/commonTest/kotlin/com/bnorm/storyboard/HeckelDiffTest.kt
+++ b/storyboard-warp/src/commonTest/kotlin/com/bnorm/storyboard/HeckelDiffTest.kt
@@ -1,0 +1,126 @@
+package com.bnorm.storyboard
+
+import dev.bnorm.storyboard.Json
+import dev.bnorm.storyboard.Kotlin
+import dev.bnorm.storyboard.diff
+import dev.bnorm.storyboard.parse
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+
+class HeckelDiffTest {
+    @Test
+    fun basicDiff() {
+        @Language("kotlin")
+        val slideP = """
+            val x = 10
+        """.trimIndent()
+
+        @Language("kotlin")
+        val slideC = """
+            val y = 10
+        """.trimIndent()
+
+        val previous = parse(code = slideP, language = Kotlin)
+        val current = parse(code = slideC, language = Kotlin)
+        val changes = diff(previous = previous, current = current)
+        changes.forEach { change ->
+            println(change)
+        }
+    }
+
+    @Test
+    fun basicDiff2() {
+        @Language("kotlin")
+        val slideP = """
+            val x = 10
+        """.trimIndent()
+
+        @Language("kotlin")
+        val slideC = """
+            val x = 20
+        """.trimIndent()
+
+        val previous = parse(code = slideP, language = Kotlin)
+        val current = parse(code = slideC, language = Kotlin)
+        val changes = diff(previous = previous, current = current)
+        changes.forEach { change ->
+            println(change)
+        }
+    }
+
+    @Test
+    fun lineMoveDiff() {
+        @Language("kotlin")
+        val slideP = """
+            val x = 10
+            fun convert(input: Int) {
+              // ...
+            }
+        """.trimIndent()
+
+        @Language("kotlin")
+        val slideC = """
+            val x = 10
+            fun convert(input: Int) {
+              println("The actual implementation")
+            }
+        """.trimIndent()
+
+        val previous = parse(code = slideP, language = Kotlin)
+        val current = parse(code = slideC, language = Kotlin)
+        val changes = diff(previous = previous, current = current)
+        changes.forEach { change ->
+            println(change)
+        }
+    }
+
+    @Test
+    fun lineMoveDiff2() {
+        @Language("kotlin")
+        val slideP = """
+            val a = 10
+            val b = 20
+            val c = 30
+        """.trimIndent()
+
+        @Language("kotlin")
+        val slideC = """
+            val b = 20
+            val c = 30
+            val d = 40
+        """.trimIndent()
+
+        val previous = parse(code = slideP, language = Kotlin)
+        val current = parse(code = slideC, language = Kotlin)
+        val changes = diff(previous = previous, current = current)
+        changes.forEach { change ->
+            println(change)
+        }
+    }
+
+    @Test
+    fun basicJsonDiff() {
+        @Language("json")
+        val slideP = """
+            {
+              "a" : 10,
+              "b" : [1, 2]
+            }
+        """.trimIndent()
+
+        @Language("json")
+        val slideC = """
+            {
+              "a" : 10,
+              "b" : [1, 2, 3]
+            }
+        """.trimIndent()
+
+        val previous = parse(code = slideP, language = Json)
+        val current = parse(code = slideC, language = Json)
+        val changes = diff(previous = previous, current = current)
+        changes.forEach { change ->
+            println(change)
+        }
+    }
+}

--- a/storyboard-warp/src/jvmMain/kotlin/dev/bnorm/storyboard/Parser.jvm.kt
+++ b/storyboard-warp/src/jvmMain/kotlin/dev/bnorm/storyboard/Parser.jvm.kt
@@ -1,0 +1,114 @@
+package dev.bnorm.storyboard
+
+import androidx.collection.ScatterMap
+import androidx.collection.mutableScatterMapOf
+import org.eclipse.tm4e.core.grammar.IGrammar
+import org.eclipse.tm4e.core.grammar.IStateStack
+import org.eclipse.tm4e.core.grammar.IToken
+import org.eclipse.tm4e.core.grammar.ITokenizeLineResult
+import org.eclipse.tm4e.core.internal.grammar.StateStack
+import org.eclipse.tm4e.core.registry.IGrammarSource
+import org.eclipse.tm4e.core.registry.IRegistryOptions
+import org.eclipse.tm4e.core.registry.Registry
+import java.util.logging.Level
+import java.util.logging.Logger
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+
+actual fun parse(code: String, language: Language): List<Token> {
+    // Keep logs clean.
+    Logger.getLogger(org.eclipse.tm4e.core.internal.rule.RuleFactory::class.qualifiedName).level = Level.SEVERE
+    return when (language) {
+        is Custom -> {
+            language.parser.parse(code)
+        }
+
+        else -> {
+            val grammar = languageGrammar(language = language)
+            check(grammar != null) { "Unable to load grammar for $language. Have you registered the grammar ?" }
+
+            // Keeps track of incomplete parse state between lines.
+            var state: IStateStack = StateStack.NULL
+            val tokens = mutableListOf<Token>()
+            code.lines().forEachIndexed { lineNumber, line ->
+                val result: ITokenizeLineResult<Array<IToken>> = grammar.tokenizeLine(
+                    /* lineText = */ line,
+                    /* prevState = */ state,
+                    /* timeLimit = */ PARSE_DURATION
+                )
+                // This should never really happen
+                require(!result.isStoppedEarly)
+                result.tokens.forEach { token ->
+                    // TM4E sometimes implicitly adds line-endings to lines when using RegExp matchers.
+                    // For e.g. Comments are matched with a `<pattern>$` and therefore an implicit
+                    // line ending is added. We therefore need to clamp start and end indexes.
+                    val startIndex = token.startIndex.coerceIn(0, line.length)
+                    val endIndex = token.endIndex.coerceIn(startIndex, line.length)
+                    val content = line.substring(startIndex = startIndex, endIndex = endIndex)
+                    val scopes = token.scopes
+                    // The primary scope is always the last one.
+                    val scope = scopes.last()
+                    val depth = scopes.size
+                    tokens += Token(
+                        content = content,
+                        scope = scope,
+                        depth = depth,
+                        language = language,
+                        allScopes = scopes,
+                        lineNumber = lineNumber,
+                        startIndex = startIndex,
+                        endIndex = endIndex
+                    )
+                }
+                // Update state
+                state = result.ruleStack
+            }
+            tokens
+        }
+    }
+}
+
+/** How long does E4TM parse until before giving up. */
+// In practice, this should never take this long.
+internal val PARSE_DURATION = 1.minutes.toJavaDuration()
+
+internal fun languageGrammar(language: Language): IGrammar? {
+    val registry = LanguageRegistry(language)
+    return registry.loadGrammar(language.scopeName())
+}
+
+/**
+ * A registry of known languages that can parsed and tokenized.
+ *
+ * To add a new language, do the following:
+ * * Obtain the grammar file from: https://github.com/shikijs/textmate-grammars-themes/tree/main/packages/tm-grammars/raw
+ * * The `scopeName` is a part of the `JSON` with the key `scopeName`.
+ * * Copy the grammar file into `resources`
+ * * Create a mapping from the `Language` to the name of the grammar `resource`.
+ */
+val GRAMMAR_REGISTRY: ScatterMap<Language, Lazy<IGrammarSource>> = mutableScatterMapOf(
+    Json to grammarResource(name = "json.tmLanguage.json"),
+    Kotlin to grammarResource(name = "kotlin.tmLanguage.json"),
+    Xml to grammarResource("xml.tmLanguage.json"),
+)
+
+internal fun grammarResource(
+    name: String,
+    contentType: IGrammarSource.ContentType = IGrammarSource.ContentType.JSON
+): Lazy<IGrammarSource> {
+    return lazy(mode = LazyThreadSafetyMode.PUBLICATION) {
+        val stream = Thread.currentThread().contextClassLoader.getResourceAsStream(name)
+
+        val grammarText = stream.use { stream!!.bufferedReader().readText() }
+        // JSON content type, given we are pulling in grammars from Shiki.
+        val grammar = IGrammarSource.fromString(contentType, grammarText)
+        require(grammar != null) { "Unable to load grammar for $name" }
+        grammar
+    }
+}
+
+class LanguageRegistry(private val language: Language) : Registry(object : IRegistryOptions {
+    override fun getGrammarSource(scopeName: String): IGrammarSource {
+        return GRAMMAR_REGISTRY[language]?.value ?: throw IllegalStateException("Unregistered Language $language")
+    }
+})

--- a/storyboard-warp/src/jvmMain/resources/json.tmLanguage.json
+++ b/storyboard-warp/src/jvmMain/resources/json.tmLanguage.json
@@ -1,0 +1,214 @@
+{
+  "displayName": "JSON",
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/microsoft/vscode-JSON.tmLanguage/blob/master/JSON.tmLanguage",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "name": "json",
+  "patterns": [
+    {
+      "include": "#value"
+    }
+  ],
+  "repository": {
+    "array": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.begin.json"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.json"
+        }
+      },
+      "name": "meta.structure.array.json",
+      "patterns": [
+        {
+          "include": "#value"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.json"
+        },
+        {
+          "match": "[^\\s\\]]",
+          "name": "invalid.illegal.expected-array-separator.json"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*\\*(?!/)",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "end": "\\*/",
+          "name": "comment.block.documentation.json"
+        },
+        {
+          "begin": "/\\*",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "end": "\\*/",
+          "name": "comment.block.json"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "match": "(//).*$\\n?",
+          "name": "comment.line.double-slash.js"
+        }
+      ]
+    },
+    "constant": {
+      "match": "\\b(?:true|false|null)\\b",
+      "name": "constant.language.json"
+    },
+    "number": {
+      "match": "(?x)        # turn on extended mode\n  -?        # an optional minus\n  (?:\n    0       # a zero\n    |       # ...or...\n    [1-9]   # a 1-9 character\n    \\d*     # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.    # a period\n      \\d+   # followed by one or more digits\n    )?\n    (?:\n      [eE]  # an e character\n      [+-]? # followed by an option +/-\n      \\d+   # followed by one or more digits\n    )?      # make exponent optional\n  )?        # make decimal portion optional",
+      "name": "constant.numeric.json"
+    },
+    "object": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.begin.json"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.end.json"
+        }
+      },
+      "name": "meta.structure.dictionary.json",
+      "patterns": [
+        {
+          "comment": "the JSON object key",
+          "include": "#objectkey"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "begin": ":",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.dictionary.key-value.json"
+            }
+          },
+          "end": "(,)|(?=\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.separator.dictionary.pair.json"
+            }
+          },
+          "name": "meta.structure.dictionary.value.json",
+          "patterns": [
+            {
+              "comment": "the JSON object value",
+              "include": "#value"
+            },
+            {
+              "match": "[^\\s,]",
+              "name": "invalid.illegal.expected-dictionary-separator.json"
+            }
+          ]
+        },
+        {
+          "match": "[^\\s\\}]",
+          "name": "invalid.illegal.expected-dictionary-separator.json"
+        }
+      ]
+    },
+    "objectkey": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.support.type.property-name.begin.json"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.support.type.property-name.end.json"
+        }
+      },
+      "name": "string.json support.type.property-name.json",
+      "patterns": [
+        {
+          "include": "#stringcontent"
+        }
+      ]
+    },
+    "string": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.json"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.json"
+        }
+      },
+      "name": "string.quoted.double.json",
+      "patterns": [
+        {
+          "include": "#stringcontent"
+        }
+      ]
+    },
+    "stringcontent": {
+      "patterns": [
+        {
+          "match": "(?x)                # turn on extended mode\n  \\\\                # a literal backslash\n  (?:               # ...followed by...\n    [\"\\\\/bfnrt]     # one of these characters\n    |               # ...or...\n    u               # a u\n    [0-9a-fA-F]{4}) # and four hex digits",
+          "name": "constant.character.escape.json"
+        },
+        {
+          "match": "\\\\.",
+          "name": "invalid.illegal.unrecognized-string-escape.json"
+        }
+      ]
+    },
+    "value": {
+      "patterns": [
+        {
+          "include": "#constant"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.json",
+  "version": "https://github.com/microsoft/vscode-JSON.tmLanguage/commit/9bd83f1c252b375e957203f21793316203f61f70"
+}

--- a/storyboard-warp/src/jvmMain/resources/kotlin.tmLanguage.json
+++ b/storyboard-warp/src/jvmMain/resources/kotlin.tmLanguage.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "displayName": "Kotlin",
+  "fileTypes": [
+    "kt",
+    "kts"
+  ],
+  "name": "kotlin",
+  "patterns": [
+    {
+      "include": "#import"
+    },
+    {
+      "include": "#package"
+    },
+    {
+      "include": "#code"
+    }
+  ],
+  "repository": {
+    "annotation-simple": {
+      "match": "(?<!\\w)@[\\w\\.]+\\b(?!:)",
+      "name": "entity.name.type.annotation.kotlin"
+    },
+    "annotation-site": {
+      "begin": "(?<!\\w)(@\\w+):\\s*(?!\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.annotation-site.kotlin"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#unescaped-annotation"
+        }
+      ]
+    },
+    "annotation-site-list": {
+      "begin": "(?<!\\w)(@\\w+):\\s*\\[",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.annotation-site.kotlin"
+        }
+      },
+      "end": "\\]",
+      "patterns": [
+        {
+          "include": "#unescaped-annotation"
+        }
+      ]
+    },
+    "binary-literal": {
+      "match": "0(b|B)[01][01_]*",
+      "name": "constant.numeric.binary.kotlin"
+    },
+    "boolean-literal": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean.kotlin"
+    },
+    "character": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        }
+      ]
+    },
+    "class-declaration": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.class.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.class.kotlin"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(class|(?:fun\\s+)?interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    },
+    "code": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#annotation-simple"
+        },
+        {
+          "include": "#annotation-site-list"
+        },
+        {
+          "include": "#annotation-site"
+        },
+        {
+          "include": "#class-declaration"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#type-alias"
+        },
+        {
+          "include": "#function"
+        },
+        {
+          "include": "#variable-declaration"
+        },
+        {
+          "include": "#type-constraint"
+        },
+        {
+          "include": "#type-annotation"
+        },
+        {
+          "include": "#function-call"
+        },
+        {
+          "include": "#method-reference"
+        },
+        {
+          "include": "#key"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#string-empty"
+        },
+        {
+          "include": "#string-multiline"
+        },
+        {
+          "include": "#character"
+        },
+        {
+          "include": "#lambda-arrow"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#self-reference"
+        },
+        {
+          "include": "#decimal-literal"
+        },
+        {
+          "include": "#hex-literal"
+        },
+        {
+          "include": "#binary-literal"
+        },
+        {
+          "include": "#boolean-literal"
+        },
+        {
+          "include": "#null-literal"
+        }
+      ]
+    },
+    "comment-block": {
+      "begin": "/\\*(?!\\*)",
+      "end": "\\*/",
+      "name": "comment.block.kotlin"
+    },
+    "comment-javadoc": {
+      "patterns": [
+        {
+          "begin": "/\\*\\*",
+          "end": "\\*/",
+          "name": "comment.block.javadoc.kotlin",
+          "patterns": [
+            {
+              "match": "@(return|constructor|receiver|sample|see|author|since|suppress)\\b",
+              "name": "keyword.other.documentation.javadoc.kotlin"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "(@param|@property)\\s+(\\S+)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "(@param)\\[(\\S+)\\]"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "entity.name.type.class.kotlin"
+                }
+              },
+              "match": "(@(?:exception|throws))\\s+(\\S+)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "entity.name.type.class.kotlin"
+                },
+                "3": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}"
+            }
+          ]
+        }
+      ]
+    },
+    "comment-line": {
+      "begin": "//",
+      "end": "$",
+      "name": "comment.line.double-slash.kotlin"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "include": "#comment-line"
+        },
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#comment-javadoc"
+        }
+      ]
+    },
+    "control-keywords": {
+      "match": "\\b(if|else|while|do|when|try|throw|break|continue|return|for)\\b",
+      "name": "keyword.control.kotlin"
+    },
+    "decimal-literal": {
+      "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(u|U)?(L|F|f)?\\b",
+      "name": "constant.numeric.decimal.kotlin"
+    },
+    "function": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.fun.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        },
+        "4": {
+          "name": "entity.name.type.class.extension.kotlin"
+        },
+        "5": {
+          "name": "entity.name.function.declaration.kotlin"
+        }
+      },
+      "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`))?"
+    },
+    "function-call": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.call.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\??\\.?(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?=[({])"
+    },
+    "hard-keywords": {
+      "match": "\\b(as|typeof|is|in)\\b",
+      "name": "keyword.hard.kotlin"
+    },
+    "hex-literal": {
+      "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*(u|U)?",
+      "name": "constant.numeric.hex.kotlin"
+    },
+    "import": {
+      "begin": "\\b(import)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.soft.kotlin"
+        }
+      },
+      "contentName": "entity.name.package.kotlin",
+      "end": ";|$",
+      "name": "meta.import.kotlin",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#hard-keywords"
+        },
+        {
+          "match": "\\*",
+          "name": "variable.language.wildcard.kotlin"
+        }
+      ]
+    },
+    "key": {
+      "captures": {
+        "1": {
+          "name": "variable.parameter.kotlin"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.kotlin"
+        }
+      },
+      "match": "\\b(\\w=)\\s*(=)"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "include": "#prefix-modifiers"
+        },
+        {
+          "include": "#postfix-modifiers"
+        },
+        {
+          "include": "#soft-keywords"
+        },
+        {
+          "include": "#hard-keywords"
+        },
+        {
+          "include": "#control-keywords"
+        }
+      ]
+    },
+    "lambda-arrow": {
+      "match": "->",
+      "name": "storage.type.function.arrow.kotlin"
+    },
+    "method-reference": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.reference.kotlin"
+        }
+      },
+      "match": "\\??::(\\b\\w+\\b|`[^`]+`)"
+    },
+    "null-literal": {
+      "match": "\\bnull\\b",
+      "name": "constant.language.null.kotlin"
+    },
+    "object": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.object.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.object.kotlin"
+        }
+      },
+      "match": "\\b(object)(?:\\s+(\\b\\w+\\b|`[^`]+`))?"
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "(===?|\\!==?|<=|>=|<|>)",
+          "name": "keyword.operator.comparison.kotlin"
+        },
+        {
+          "match": "([+*/%-]=)",
+          "name": "keyword.operator.assignment.arithmetic.kotlin"
+        },
+        {
+          "match": "(=)",
+          "name": "keyword.operator.assignment.kotlin"
+        },
+        {
+          "match": "([+*/%-])",
+          "name": "keyword.operator.arithmetic.kotlin"
+        },
+        {
+          "match": "(!|&&|\\|\\|)",
+          "name": "keyword.operator.logical.kotlin"
+        },
+        {
+          "match": "(--|\\+\\+)",
+          "name": "keyword.operator.increment-decrement.kotlin"
+        },
+        {
+          "match": "(\\.\\.)",
+          "name": "keyword.operator.range.kotlin"
+        }
+      ]
+    },
+    "package": {
+      "begin": "\\b(package)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.hard.package.kotlin"
+        }
+      },
+      "contentName": "entity.name.package.kotlin",
+      "end": ";|$",
+      "name": "meta.package.kotlin",
+      "patterns": [
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "postfix-modifiers": {
+      "match": "\\b(where|by|get|set)\\b",
+      "name": "storage.modifier.other.kotlin"
+    },
+    "prefix-modifiers": {
+      "match": "\\b(abstract|final|enum|open|annotation|sealed|data|override|final|lateinit|private|protected|public|internal|inner|companion|noinline|crossinline|vararg|reified|tailrec|operator|infix|inline|external|const|suspend|value)\\b",
+      "name": "storage.modifier.other.kotlin"
+    },
+    "self-reference": {
+      "match": "\\b(this|super)(@\\w+)?\\b",
+      "name": "variable.language.this.kotlin"
+    },
+    "soft-keywords": {
+      "match": "\\b(init|catch|finally|field)\\b",
+      "name": "keyword.soft.kotlin"
+    },
+    "string": {
+      "begin": "(?<!\")\"(?!\")",
+      "end": "\"",
+      "name": "string.quoted.double.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        },
+        {
+          "include": "#string-escape-simple"
+        },
+        {
+          "include": "#string-escape-bracketed"
+        }
+      ]
+    },
+    "string-empty": {
+      "match": "(?<!\")\"\"(?!\")",
+      "name": "string.quoted.double.kotlin"
+    },
+    "string-escape-bracketed": {
+      "begin": "(?<!\\\\)(\\$\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.template-expression.begin"
+        }
+      },
+      "end": "(\\})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.template-expression.end"
+        }
+      },
+      "name": "meta.template.expression.kotlin",
+      "patterns": [
+        {
+          "include": "#code"
+        }
+      ]
+    },
+    "string-escape-simple": {
+      "match": "(?<!\\\\)\\$\\w+\\b",
+      "name": "variable.string-escape.kotlin"
+    },
+    "string-multiline": {
+      "begin": "\"\"\"",
+      "end": "\"\"\"",
+      "name": "string.quoted.double.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        },
+        {
+          "include": "#string-escape-simple"
+        },
+        {
+          "include": "#string-escape-bracketed"
+        }
+      ]
+    },
+    "type-alias": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.typealias.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.kotlin"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(typealias)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    },
+    "type-annotation": {
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "(?<![:?]):\\s*(\\w|\\?|\\s|->|(?<GROUP>[<(]([^<>()\"']|\\g<GROUP>)+[)>]))+"
+    },
+    "type-parameter": {
+      "patterns": [
+        {
+          "match": "\\b\\w+\\b",
+          "name": "entity.name.type.kotlin"
+        },
+        {
+          "match": "\\b(in|out)\\b",
+          "name": "storage.modifier.kotlin"
+        }
+      ]
+    },
+    "unescaped-annotation": {
+      "match": "\\b[\\w\\.]+\\b",
+      "name": "entity.name.type.annotation.kotlin"
+    },
+    "variable-declaration": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(val|var)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    }
+  },
+  "scopeName": "source.kotlin"
+}

--- a/storyboard-warp/src/jvmMain/resources/xml.tmLanguage.json
+++ b/storyboard-warp/src/jvmMain/resources/xml.tmLanguage.json
@@ -1,0 +1,388 @@
+{
+  "displayName": "XML",
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/atom/language-xml/blob/master/grammars/xml.cson",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "name": "xml",
+  "patterns": [
+    {
+      "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.xml"
+        }
+      },
+      "end": "(\\?>)",
+      "name": "meta.tag.preprocessor.xml",
+      "patterns": [
+        {
+          "match": " ([a-zA-Z-]+)",
+          "name": "entity.other.attribute-name.xml"
+        },
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    },
+    {
+      "begin": "(<!)(DOCTYPE)\\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "keyword.other.doctype.xml"
+        },
+        "3": {
+          "name": "variable.language.documentroot.xml"
+        }
+      },
+      "end": "\\s*(>)",
+      "name": "meta.tag.sgml.doctype.xml",
+      "patterns": [
+        {
+          "include": "#internalSubset"
+        }
+      ]
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "4": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "5": {
+          "name": "entity.name.tag.localname.xml"
+        }
+      },
+      "end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.xml"
+        },
+        "4": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "5": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "6": {
+          "name": "entity.name.tag.localname.xml"
+        },
+        "7": {
+          "name": "punctuation.definition.tag.xml"
+        }
+      },
+      "name": "meta.tag.no-content.xml",
+      "patterns": [
+        {
+          "include": "#tagStuff"
+        }
+      ]
+    },
+    {
+      "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.xml"
+        },
+        "4": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "5": {
+          "name": "entity.name.tag.localname.xml"
+        }
+      },
+      "end": "(/?>)",
+      "name": "meta.tag.xml",
+      "patterns": [
+        {
+          "include": "#tagStuff"
+        }
+      ]
+    },
+    {
+      "include": "#entity"
+    },
+    {
+      "include": "#bare-ampersand"
+    },
+    {
+      "begin": "<%@",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.xml"
+        }
+      },
+      "end": "%>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.xml"
+        }
+      },
+      "name": "source.java-props.embedded.xml",
+      "patterns": [
+        {
+          "match": "page|include|taglib",
+          "name": "keyword.other.page-props.xml"
+        }
+      ]
+    },
+    {
+      "begin": "<%[!=]?(?!--)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.xml"
+        }
+      },
+      "end": "(?!--)%>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.xml"
+        }
+      },
+      "name": "source.java.embedded.xml",
+      "patterns": [
+        {
+          "include": "source.java"
+        }
+      ]
+    },
+    {
+      "begin": "<!\\[CDATA\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "]]>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.unquoted.cdata.xml"
+    }
+  ],
+  "repository": {
+    "EntityDecl": {
+      "begin": "(<!)(ENTITY)\\s+(%\\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\\s+(?:SYSTEM|PUBLIC)\\s+)?",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "keyword.other.entity.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.entity.xml"
+        },
+        "4": {
+          "name": "variable.language.entity.xml"
+        },
+        "5": {
+          "name": "keyword.other.entitytype.xml"
+        }
+      },
+      "end": "(>)",
+      "patterns": [
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    },
+    "bare-ampersand": {
+      "match": "&",
+      "name": "invalid.illegal.bad-ampersand.xml"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "<%--",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.xml"
+            },
+            "end": "--%>",
+            "name": "comment.block.xml"
+          }
+        },
+        {
+          "begin": "<!--",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.xml"
+            }
+          },
+          "end": "-->",
+          "name": "comment.block.xml",
+          "patterns": [
+            {
+              "begin": "--(?!>)",
+              "captures": {
+                "0": {
+                  "name": "invalid.illegal.bad-comments-or-CDATA.xml"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "doublequotedString": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.quoted.double.xml",
+      "patterns": [
+        {
+          "include": "#entity"
+        },
+        {
+          "include": "#bare-ampersand"
+        }
+      ]
+    },
+    "entity": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+      "name": "constant.character.entity.xml"
+    },
+    "internalSubset": {
+      "begin": "(\\[)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "end": "(\\])",
+      "name": "meta.internalsubset.xml",
+      "patterns": [
+        {
+          "include": "#EntityDecl"
+        },
+        {
+          "include": "#parameterEntity"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "parameterEntity": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+      "name": "constant.character.parameter-entity.xml"
+    },
+    "singlequotedString": {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.quoted.single.xml",
+      "patterns": [
+        {
+          "include": "#entity"
+        },
+        {
+          "include": "#bare-ampersand"
+        }
+      ]
+    },
+    "tagStuff": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "entity.other.attribute-name.namespace.xml"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.xml"
+            },
+            "3": {
+              "name": "punctuation.separator.namespace.xml"
+            },
+            "4": {
+              "name": "entity.other.attribute-name.localname.xml"
+            }
+          },
+          "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
+        },
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    }
+  },
+  "scopeName": "text.xml",
+  "version": "https://github.com/atom/language-xml/commit/7bc75dfe779ad5b35d9bf4013d9181864358cb49"
+}

--- a/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Json.kt
+++ b/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Json.kt
@@ -1,0 +1,11 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package dev.bnorm.storyboard
+
+import kotlin.js.JsAny
+import kotlin.js.JsString
+
+external object JSON {
+    fun parse(text: JsString): JsAny
+    fun stringify(value: JsAny): JsString
+}

--- a/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/LanguageRegistry.kt
+++ b/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/LanguageRegistry.kt
@@ -1,0 +1,1627 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package dev.bnorm.storyboard
+
+import androidx.collection.ScatterMap
+import androidx.collection.mutableScatterMapOf
+
+val THEME = JSON.parse(SolarizedDarkTheme.toJsString())
+const val THEME_NAME = "solarized-dark"
+
+val LANGUAGE_REGISTRY: ScatterMap<Language, JsAny> = mutableScatterMapOf(
+    Json to JSON.parse(JsonGrammar.toJsString()),
+    Xml to JSON.parse(XmlGrammar.toJsString()),
+    Kotlin to JSON.parse(KotlinGrammar.toJsString())
+)
+
+val LANGUAGE_NAMES: ScatterMap<Language, String> = mutableScatterMapOf(
+    Json to "json",
+    Xml to "xml",
+    Kotlin to "kotlin"
+)
+
+// Grammars
+
+@org.intellij.lang.annotations.Language("json")
+private const val JsonGrammar = """
+{
+  "displayName": "JSON",
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/microsoft/vscode-JSON.tmLanguage/blob/master/JSON.tmLanguage",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "name": "json",
+  "patterns": [
+    {
+      "include": "#value"
+    }
+  ],
+  "repository": {
+    "array": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.begin.json"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.json"
+        }
+      },
+      "name": "meta.structure.array.json",
+      "patterns": [
+        {
+          "include": "#value"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.array.json"
+        },
+        {
+          "match": "[^\\s\\]]",
+          "name": "invalid.illegal.expected-array-separator.json"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*\\*(?!/)",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "end": "\\*/",
+          "name": "comment.block.documentation.json"
+        },
+        {
+          "begin": "/\\*",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "end": "\\*/",
+          "name": "comment.block.json"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.json"
+            }
+          },
+          "match": "(//).*$\\n?",
+          "name": "comment.line.double-slash.js"
+        }
+      ]
+    },
+    "constant": {
+      "match": "\\b(?:true|false|null)\\b",
+      "name": "constant.language.json"
+    },
+    "number": {
+      "match": "(?x)        # turn on extended mode\n  -?        # an optional minus\n  (?:\n    0       # a zero\n    |       # ...or...\n    [1-9]   # a 1-9 character\n    \\d*     # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.    # a period\n      \\d+   # followed by one or more digits\n    )?\n    (?:\n      [eE]  # an e character\n      [+-]? # followed by an option +/-\n      \\d+   # followed by one or more digits\n    )?      # make exponent optional\n  )?        # make decimal portion optional",
+      "name": "constant.numeric.json"
+    },
+    "object": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.begin.json"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.dictionary.end.json"
+        }
+      },
+      "name": "meta.structure.dictionary.json",
+      "patterns": [
+        {
+          "comment": "the JSON object key",
+          "include": "#objectkey"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "begin": ":",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.dictionary.key-value.json"
+            }
+          },
+          "end": "(,)|(?=\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.separator.dictionary.pair.json"
+            }
+          },
+          "name": "meta.structure.dictionary.value.json",
+          "patterns": [
+            {
+              "comment": "the JSON object value",
+              "include": "#value"
+            },
+            {
+              "match": "[^\\s,]",
+              "name": "invalid.illegal.expected-dictionary-separator.json"
+            }
+          ]
+        },
+        {
+          "match": "[^\\s\\}]",
+          "name": "invalid.illegal.expected-dictionary-separator.json"
+        }
+      ]
+    },
+    "objectkey": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.support.type.property-name.begin.json"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.support.type.property-name.end.json"
+        }
+      },
+      "name": "string.json support.type.property-name.json",
+      "patterns": [
+        {
+          "include": "#stringcontent"
+        }
+      ]
+    },
+    "string": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.json"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.json"
+        }
+      },
+      "name": "string.quoted.double.json",
+      "patterns": [
+        {
+          "include": "#stringcontent"
+        }
+      ]
+    },
+    "stringcontent": {
+      "patterns": [
+        {
+          "match": "(?x)                # turn on extended mode\n  \\\\                # a literal backslash\n  (?:               # ...followed by...\n    [\"\\\\/bfnrt]     # one of these characters\n    |               # ...or...\n    u               # a u\n    [0-9a-fA-F]{4}) # and four hex digits",
+          "name": "constant.character.escape.json"
+        },
+        {
+          "match": "\\\\.",
+          "name": "invalid.illegal.unrecognized-string-escape.json"
+        }
+      ]
+    },
+    "value": {
+      "patterns": [
+        {
+          "include": "#constant"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.json",
+  "version": "https://github.com/microsoft/vscode-JSON.tmLanguage/commit/9bd83f1c252b375e957203f21793316203f61f70"
+}
+"""
+
+@org.intellij.lang.annotations.Language("json")
+private const val KotlinGrammar = $$"""
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "displayName": "Kotlin",
+  "fileTypes": [
+    "kt",
+    "kts"
+  ],
+  "name": "kotlin",
+  "patterns": [
+    {
+      "include": "#import"
+    },
+    {
+      "include": "#package"
+    },
+    {
+      "include": "#code"
+    }
+  ],
+  "repository": {
+    "annotation-simple": {
+      "match": "(?<!\\w)@[\\w\\.]+\\b(?!:)",
+      "name": "entity.name.type.annotation.kotlin"
+    },
+    "annotation-site": {
+      "begin": "(?<!\\w)(@\\w+):\\s*(?!\\[)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.annotation-site.kotlin"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#unescaped-annotation"
+        }
+      ]
+    },
+    "annotation-site-list": {
+      "begin": "(?<!\\w)(@\\w+):\\s*\\[",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.annotation-site.kotlin"
+        }
+      },
+      "end": "\\]",
+      "patterns": [
+        {
+          "include": "#unescaped-annotation"
+        }
+      ]
+    },
+    "binary-literal": {
+      "match": "0(b|B)[01][01_]*",
+      "name": "constant.numeric.binary.kotlin"
+    },
+    "boolean-literal": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean.kotlin"
+    },
+    "character": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        }
+      ]
+    },
+    "class-declaration": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.class.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.class.kotlin"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(class|(?:fun\\s+)?interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    },
+    "code": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#annotation-simple"
+        },
+        {
+          "include": "#annotation-site-list"
+        },
+        {
+          "include": "#annotation-site"
+        },
+        {
+          "include": "#class-declaration"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#type-alias"
+        },
+        {
+          "include": "#function"
+        },
+        {
+          "include": "#variable-declaration"
+        },
+        {
+          "include": "#type-constraint"
+        },
+        {
+          "include": "#type-annotation"
+        },
+        {
+          "include": "#function-call"
+        },
+        {
+          "include": "#method-reference"
+        },
+        {
+          "include": "#key"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#string-empty"
+        },
+        {
+          "include": "#string-multiline"
+        },
+        {
+          "include": "#character"
+        },
+        {
+          "include": "#lambda-arrow"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#self-reference"
+        },
+        {
+          "include": "#decimal-literal"
+        },
+        {
+          "include": "#hex-literal"
+        },
+        {
+          "include": "#binary-literal"
+        },
+        {
+          "include": "#boolean-literal"
+        },
+        {
+          "include": "#null-literal"
+        }
+      ]
+    },
+    "comment-block": {
+      "begin": "/\\*(?!\\*)",
+      "end": "\\*/",
+      "name": "comment.block.kotlin"
+    },
+    "comment-javadoc": {
+      "patterns": [
+        {
+          "begin": "/\\*\\*",
+          "end": "\\*/",
+          "name": "comment.block.javadoc.kotlin",
+          "patterns": [
+            {
+              "match": "@(return|constructor|receiver|sample|see|author|since|suppress)\\b",
+              "name": "keyword.other.documentation.javadoc.kotlin"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "(@param|@property)\\s+(\\S+)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "(@param)\\[(\\S+)\\]"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "entity.name.type.class.kotlin"
+                }
+              },
+              "match": "(@(?:exception|throws))\\s+(\\S+)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "name": "keyword.other.documentation.javadoc.kotlin"
+                },
+                "2": {
+                  "name": "entity.name.type.class.kotlin"
+                },
+                "3": {
+                  "name": "variable.parameter.kotlin"
+                }
+              },
+              "match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}"
+            }
+          ]
+        }
+      ]
+    },
+    "comment-line": {
+      "begin": "//",
+      "end": "$",
+      "name": "comment.line.double-slash.kotlin"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "include": "#comment-line"
+        },
+        {
+          "include": "#comment-block"
+        },
+        {
+          "include": "#comment-javadoc"
+        }
+      ]
+    },
+    "control-keywords": {
+      "match": "\\b(if|else|while|do|when|try|throw|break|continue|return|for)\\b",
+      "name": "keyword.control.kotlin"
+    },
+    "decimal-literal": {
+      "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(u|U)?(L|F|f)?\\b",
+      "name": "constant.numeric.decimal.kotlin"
+    },
+    "function": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.fun.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        },
+        "4": {
+          "name": "entity.name.type.class.extension.kotlin"
+        },
+        "5": {
+          "name": "entity.name.function.declaration.kotlin"
+        }
+      },
+      "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`))?"
+    },
+    "function-call": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.call.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\??\\.?(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?=[({])"
+    },
+    "hard-keywords": {
+      "match": "\\b(as|typeof|is|in)\\b",
+      "name": "keyword.hard.kotlin"
+    },
+    "hex-literal": {
+      "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*(u|U)?",
+      "name": "constant.numeric.hex.kotlin"
+    },
+    "import": {
+      "begin": "\\b(import)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.soft.kotlin"
+        }
+      },
+      "contentName": "entity.name.package.kotlin",
+      "end": ";|$",
+      "name": "meta.import.kotlin",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#hard-keywords"
+        },
+        {
+          "match": "\\*",
+          "name": "variable.language.wildcard.kotlin"
+        }
+      ]
+    },
+    "key": {
+      "captures": {
+        "1": {
+          "name": "variable.parameter.kotlin"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.kotlin"
+        }
+      },
+      "match": "\\b(\\w=)\\s*(=)"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "include": "#prefix-modifiers"
+        },
+        {
+          "include": "#postfix-modifiers"
+        },
+        {
+          "include": "#soft-keywords"
+        },
+        {
+          "include": "#hard-keywords"
+        },
+        {
+          "include": "#control-keywords"
+        }
+      ]
+    },
+    "lambda-arrow": {
+      "match": "->",
+      "name": "storage.type.function.arrow.kotlin"
+    },
+    "method-reference": {
+      "captures": {
+        "1": {
+          "name": "entity.name.function.reference.kotlin"
+        }
+      },
+      "match": "\\??::(\\b\\w+\\b|`[^`]+`)"
+    },
+    "null-literal": {
+      "match": "\\bnull\\b",
+      "name": "constant.language.null.kotlin"
+    },
+    "object": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.object.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.object.kotlin"
+        }
+      },
+      "match": "\\b(object)(?:\\s+(\\b\\w+\\b|`[^`]+`))?"
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "(===?|\\!==?|<=|>=|<|>)",
+          "name": "keyword.operator.comparison.kotlin"
+        },
+        {
+          "match": "([+*/%-]=)",
+          "name": "keyword.operator.assignment.arithmetic.kotlin"
+        },
+        {
+          "match": "(=)",
+          "name": "keyword.operator.assignment.kotlin"
+        },
+        {
+          "match": "([+*/%-])",
+          "name": "keyword.operator.arithmetic.kotlin"
+        },
+        {
+          "match": "(!|&&|\\|\\|)",
+          "name": "keyword.operator.logical.kotlin"
+        },
+        {
+          "match": "(--|\\+\\+)",
+          "name": "keyword.operator.increment-decrement.kotlin"
+        },
+        {
+          "match": "(\\.\\.)",
+          "name": "keyword.operator.range.kotlin"
+        }
+      ]
+    },
+    "package": {
+      "begin": "\\b(package)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.hard.package.kotlin"
+        }
+      },
+      "contentName": "entity.name.package.kotlin",
+      "end": ";|$",
+      "name": "meta.package.kotlin",
+      "patterns": [
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "postfix-modifiers": {
+      "match": "\\b(where|by|get|set)\\b",
+      "name": "storage.modifier.other.kotlin"
+    },
+    "prefix-modifiers": {
+      "match": "\\b(abstract|final|enum|open|annotation|sealed|data|override|final|lateinit|private|protected|public|internal|inner|companion|noinline|crossinline|vararg|reified|tailrec|operator|infix|inline|external|const|suspend|value)\\b",
+      "name": "storage.modifier.other.kotlin"
+    },
+    "self-reference": {
+      "match": "\\b(this|super)(@\\w+)?\\b",
+      "name": "variable.language.this.kotlin"
+    },
+    "soft-keywords": {
+      "match": "\\b(init|catch|finally|field)\\b",
+      "name": "keyword.soft.kotlin"
+    },
+    "string": {
+      "begin": "(?<!\")\"(?!\")",
+      "end": "\"",
+      "name": "string.quoted.double.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        },
+        {
+          "include": "#string-escape-simple"
+        },
+        {
+          "include": "#string-escape-bracketed"
+        }
+      ]
+    },
+    "string-empty": {
+      "match": "(?<!\")\"\"(?!\")",
+      "name": "string.quoted.double.kotlin"
+    },
+    "string-escape-bracketed": {
+      "begin": "(?<!\\\\)(\\$\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.template-expression.begin"
+        }
+      },
+      "end": "(\\})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.template-expression.end"
+        }
+      },
+      "name": "meta.template.expression.kotlin",
+      "patterns": [
+        {
+          "include": "#code"
+        }
+      ]
+    },
+    "string-escape-simple": {
+      "match": "(?<!\\\\)\\$\\w+\\b",
+      "name": "variable.string-escape.kotlin"
+    },
+    "string-multiline": {
+      "begin": "\"\"\"",
+      "end": "\"\"\"",
+      "name": "string.quoted.double.kotlin",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.kotlin"
+        },
+        {
+          "include": "#string-escape-simple"
+        },
+        {
+          "include": "#string-escape-bracketed"
+        }
+      ]
+    },
+    "type-alias": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.typealias.kotlin"
+        },
+        "2": {
+          "name": "entity.name.type.kotlin"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(typealias)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    },
+    "type-annotation": {
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "(?<![:?]):\\s*(\\w|\\?|\\s|->|(?<GROUP>[<(]([^<>()\"']|\\g<GROUP>)+[)>]))+"
+    },
+    "type-parameter": {
+      "patterns": [
+        {
+          "match": "\\b\\w+\\b",
+          "name": "entity.name.type.kotlin"
+        },
+        {
+          "match": "\\b(in|out)\\b",
+          "name": "storage.modifier.kotlin"
+        }
+      ]
+    },
+    "unescaped-annotation": {
+      "match": "\\b[\\w\\.]+\\b",
+      "name": "entity.name.type.annotation.kotlin"
+    },
+    "variable-declaration": {
+      "captures": {
+        "1": {
+          "name": "keyword.hard.kotlin"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type-parameter"
+            }
+          ]
+        }
+      },
+      "match": "\\b(val|var)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?"
+    }
+  },
+  "scopeName": "source.kotlin"
+}
+"""
+
+@org.intellij.lang.annotations.Language("json")
+private const val XmlGrammar = """
+{
+  "displayName": "XML",
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/atom/language-xml/blob/master/grammars/xml.cson",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "name": "xml",
+  "patterns": [
+    {
+      "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.xml"
+        }
+      },
+      "end": "(\\?>)",
+      "name": "meta.tag.preprocessor.xml",
+      "patterns": [
+        {
+          "match": " ([a-zA-Z-]+)",
+          "name": "entity.other.attribute-name.xml"
+        },
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    },
+    {
+      "begin": "(<!)(DOCTYPE)\\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "keyword.other.doctype.xml"
+        },
+        "3": {
+          "name": "variable.language.documentroot.xml"
+        }
+      },
+      "end": "\\s*(>)",
+      "name": "meta.tag.sgml.doctype.xml",
+      "patterns": [
+        {
+          "include": "#internalSubset"
+        }
+      ]
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "4": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "5": {
+          "name": "entity.name.tag.localname.xml"
+        }
+      },
+      "end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.xml"
+        },
+        "4": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "5": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "6": {
+          "name": "entity.name.tag.localname.xml"
+        },
+        "7": {
+          "name": "punctuation.definition.tag.xml"
+        }
+      },
+      "name": "meta.tag.no-content.xml",
+      "patterns": [
+        {
+          "include": "#tagStuff"
+        }
+      ]
+    },
+    {
+      "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "entity.name.tag.namespace.xml"
+        },
+        "3": {
+          "name": "entity.name.tag.xml"
+        },
+        "4": {
+          "name": "punctuation.separator.namespace.xml"
+        },
+        "5": {
+          "name": "entity.name.tag.localname.xml"
+        }
+      },
+      "end": "(/?>)",
+      "name": "meta.tag.xml",
+      "patterns": [
+        {
+          "include": "#tagStuff"
+        }
+      ]
+    },
+    {
+      "include": "#entity"
+    },
+    {
+      "include": "#bare-ampersand"
+    },
+    {
+      "begin": "<%@",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.xml"
+        }
+      },
+      "end": "%>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.xml"
+        }
+      },
+      "name": "source.java-props.embedded.xml",
+      "patterns": [
+        {
+          "match": "page|include|taglib",
+          "name": "keyword.other.page-props.xml"
+        }
+      ]
+    },
+    {
+      "begin": "<%[!=]?(?!--)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.xml"
+        }
+      },
+      "end": "(?!--)%>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.xml"
+        }
+      },
+      "name": "source.java.embedded.xml",
+      "patterns": [
+        {
+          "include": "source.java"
+        }
+      ]
+    },
+    {
+      "begin": "<!\\[CDATA\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "]]>",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.unquoted.cdata.xml"
+    }
+  ],
+  "repository": {
+    "EntityDecl": {
+      "begin": "(<!)(ENTITY)\\s+(%\\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\\s+(?:SYSTEM|PUBLIC)\\s+)?",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.tag.xml"
+        },
+        "2": {
+          "name": "keyword.other.entity.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.entity.xml"
+        },
+        "4": {
+          "name": "variable.language.entity.xml"
+        },
+        "5": {
+          "name": "keyword.other.entitytype.xml"
+        }
+      },
+      "end": "(>)",
+      "patterns": [
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    },
+    "bare-ampersand": {
+      "match": "&",
+      "name": "invalid.illegal.bad-ampersand.xml"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "<%--",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.xml"
+            },
+            "end": "--%>",
+            "name": "comment.block.xml"
+          }
+        },
+        {
+          "begin": "<!--",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.xml"
+            }
+          },
+          "end": "-->",
+          "name": "comment.block.xml",
+          "patterns": [
+            {
+              "begin": "--(?!>)",
+              "captures": {
+                "0": {
+                  "name": "invalid.illegal.bad-comments-or-CDATA.xml"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "doublequotedString": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.quoted.double.xml",
+      "patterns": [
+        {
+          "include": "#entity"
+        },
+        {
+          "include": "#bare-ampersand"
+        }
+      ]
+    },
+    "entity": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+      "name": "constant.character.entity.xml"
+    },
+    "internalSubset": {
+      "begin": "(\\[)",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "end": "(\\])",
+      "name": "meta.internalsubset.xml",
+      "patterns": [
+        {
+          "include": "#EntityDecl"
+        },
+        {
+          "include": "#parameterEntity"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "parameterEntity": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.xml"
+        },
+        "3": {
+          "name": "punctuation.definition.constant.xml"
+        }
+      },
+      "match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+      "name": "constant.character.parameter-entity.xml"
+    },
+    "singlequotedString": {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.xml"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.xml"
+        }
+      },
+      "name": "string.quoted.single.xml",
+      "patterns": [
+        {
+          "include": "#entity"
+        },
+        {
+          "include": "#bare-ampersand"
+        }
+      ]
+    },
+    "tagStuff": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "entity.other.attribute-name.namespace.xml"
+            },
+            "2": {
+              "name": "entity.other.attribute-name.xml"
+            },
+            "3": {
+              "name": "punctuation.separator.namespace.xml"
+            },
+            "4": {
+              "name": "entity.other.attribute-name.localname.xml"
+            }
+          },
+          "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
+        },
+        {
+          "include": "#doublequotedString"
+        },
+        {
+          "include": "#singlequotedString"
+        }
+      ]
+    }
+  },
+  "scopeName": "text.xml",
+  "version": "https://github.com/atom/language-xml/commit/7bc75dfe779ad5b35d9bf4013d9181864358cb49"
+}
+"""
+
+// Themes
+
+@org.intellij.lang.annotations.Language("json")
+private const val SolarizedDarkTheme = """
+{
+  "colors": {
+    "activityBar.background": "#003847",
+    "agentsBottomPanel.border": "#00000000",
+    "agentsCard.border": "#00000000",
+    "agentsChatInput.border": "#586E7566",
+    "agentsChatInput.focusBorder": "#2AA19899",
+    "agentsNewSessionButton.border": "#586E7566",
+    "agentsPanel.border": "#586E7566",
+    "badge.background": "#047aa6",
+    "button.background": "#2AA19899",
+    "debugExceptionWidget.background": "#00212B",
+    "debugExceptionWidget.border": "#AB395B",
+    "debugToolBar.background": "#00212B",
+    "dropdown.background": "#00212B",
+    "dropdown.border": "#2AA19899",
+    "editor.background": "#002B36",
+    "editor.foreground": "#839496",
+    "editor.lineHighlightBackground": "#073642",
+    "editor.selectionBackground": "#274642",
+    "editor.selectionHighlightBackground": "#005A6FAA",
+    "editor.wordHighlightBackground": "#004454AA",
+    "editor.wordHighlightStrongBackground": "#005A6FAA",
+    "editorBracketHighlight.foreground1": "#cdcdcdff",
+    "editorBracketHighlight.foreground2": "#b58900ff",
+    "editorBracketHighlight.foreground3": "#d33682ff",
+    "editorCursor.foreground": "#D30102",
+    "editorGroup.border": "#00212B",
+    "editorGroup.dropBackground": "#2AA19844",
+    "editorGroupHeader.tabsBackground": "#004052",
+    "editorHoverWidget.background": "#004052",
+    "editorIndentGuide.activeBackground": "#C3E1E180",
+    "editorIndentGuide.background": "#93A1A180",
+    "editorLineNumber.activeForeground": "#949494",
+    "editorMarkerNavigationError.background": "#AB395B",
+    "editorMarkerNavigationWarning.background": "#5B7E7A",
+    "editorWhitespace.foreground": "#93A1A180",
+    "editorWidget.background": "#00212B",
+    "errorForeground": "#ffeaea",
+    "focusBorder": "#2AA19899",
+    "input.background": "#003847",
+    "input.foreground": "#93A1A1",
+    "input.placeholderForeground": "#93A1A1AA",
+    "inputOption.activeBorder": "#2AA19899",
+    "inputValidation.errorBackground": "#571b26",
+    "inputValidation.errorBorder": "#a92049",
+    "inputValidation.infoBackground": "#052730",
+    "inputValidation.infoBorder": "#363b5f",
+    "inputValidation.warningBackground": "#5d5938",
+    "inputValidation.warningBorder": "#9d8a5e",
+    "list.activeSelectionBackground": "#005A6F",
+    "list.dropBackground": "#00445488",
+    "list.highlightForeground": "#1ebcc5",
+    "list.hoverBackground": "#004454AA",
+    "list.inactiveSelectionBackground": "#00445488",
+    "minimap.selectionHighlight": "#274642",
+    "modernActivityBar.activeBackground": "#005A6F",
+    "modernActivityBar.background": "#00000000",
+    "modernActivityBar.hoverBackground": "#005A6F87",
+    "panel.border": "#2b2b4a",
+    "peekView.border": "#2b2b4a",
+    "peekViewEditor.background": "#10192c",
+    "peekViewEditor.matchHighlightBackground": "#7744AA40",
+    "peekViewResult.background": "#00212B",
+    "peekViewTitle.background": "#00212B",
+    "pickerGroup.border": "#2AA19899",
+    "pickerGroup.foreground": "#2AA19899",
+    "ports.iconRunningProcessForeground": "#369432",
+    "progressBar.background": "#047aa6",
+    "quickInputList.focusBackground": "#005A6F",
+    "selection.background": "#2AA19899",
+    "sideBar.background": "#00212B",
+    "sideBarTitle.foreground": "#93A1A1",
+    "statusBar.background": "#00212B",
+    "statusBar.debuggingBackground": "#00212B",
+    "statusBar.foreground": "#93A1A1",
+    "statusBar.noFolderBackground": "#00212B",
+    "statusBarItem.prominentBackground": "#003847",
+    "statusBarItem.prominentHoverBackground": "#003847",
+    "statusBarItem.remoteBackground": "#2AA19899",
+    "surface.border": "#00222c",
+    "tab.activeBackground": "#002B37",
+    "tab.activeForeground": "#d6dbdb",
+    "tab.border": "#003847",
+    "tab.inactiveBackground": "#004052",
+    "tab.inactiveForeground": "#93A1A1",
+    "tab.lastPinnedBorder": "#2AA19844",
+    "terminal.ansiBlack": "#073642",
+    "terminal.ansiBlue": "#268bd2",
+    "terminal.ansiBrightBlack": "#002b36",
+    "terminal.ansiBrightBlue": "#839496",
+    "terminal.ansiBrightCyan": "#93a1a1",
+    "terminal.ansiBrightGreen": "#586e75",
+    "terminal.ansiBrightMagenta": "#6c71c4",
+    "terminal.ansiBrightRed": "#cb4b16",
+    "terminal.ansiBrightWhite": "#fdf6e3",
+    "terminal.ansiBrightYellow": "#657b83",
+    "terminal.ansiCyan": "#2aa198",
+    "terminal.ansiGreen": "#859900",
+    "terminal.ansiMagenta": "#d33682",
+    "terminal.ansiRed": "#dc322f",
+    "terminal.ansiWhite": "#eee8d5",
+    "terminal.ansiYellow": "#b58900",
+    "titleBar.activeBackground": "#002C39"
+  },
+  "displayName": "Solarized Dark",
+  "name": "solarized-dark",
+  "semanticHighlighting": true,
+  "tokenColors": [
+    {
+      "settings": {
+        "foreground": "#839496"
+      }
+    },
+    {
+      "scope": [
+        "meta.embedded",
+        "source.groovy.embedded",
+        "string meta.image.inline.markdown",
+        "variable.legacy.builtin.python"
+      ],
+      "settings": {
+        "foreground": "#839496"
+      }
+    },
+    {
+      "scope": "comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#586E75"
+      }
+    },
+    {
+      "scope": "string",
+      "settings": {
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "scope": [
+        "variable.language",
+        "variable.other"
+      ],
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "scope": "storage",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.class",
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.name.scope-resolution"
+      ],
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "scope": "entity.name.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "punctuation.definition.variable",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "scope": [
+        "punctuation.section.embedded.begin",
+        "punctuation.section.embedded.end"
+      ],
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "scope": [
+        "constant.language",
+        "meta.preprocessor"
+      ],
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "scope": [
+        "support.function.construct",
+        "keyword.other.new"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "scope": [
+        "constant.character",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "scope": [
+        "entity.other.inherited-class",
+        "punctuation.separator.namespace.ruby"
+      ],
+      "settings": {
+        "foreground": "#6C71C4"
+      }
+    },
+    {
+      "scope": "variable.parameter",
+      "settings": {
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "punctuation.definition.tag",
+      "settings": {
+        "foreground": "#586E75"
+      }
+    },
+    {
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#93A1A1"
+      }
+    },
+    {
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "punctuation.separator.continuation",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "scope": [
+        "support.constant",
+        "support.variable"
+      ],
+      "settings": {
+      }
+    },
+    {
+      "scope": [
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "scope": "support.type.exception",
+      "settings": {
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "scope": "support.other.variable",
+      "settings": {
+      }
+    },
+    {
+      "scope": "invalid",
+      "settings": {
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "scope": [
+        "meta.diff",
+        "meta.diff.header"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#DC322F"
+      }
+    },
+    {
+      "scope": "markup.changed",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#CB4B16"
+      }
+    },
+    {
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "scope": "markup.list",
+      "settings": {
+        "foreground": "#B58900"
+      }
+    },
+    {
+      "scope": [
+        "markup.bold",
+        "markup.italic"
+      ],
+      "settings": {
+        "foreground": "#D33682"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "scope": "markup.strikethrough",
+      "settings": {
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "scope": "markup.inline.raw",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#2AA198"
+      }
+    },
+    {
+      "scope": "markup.heading",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#268BD2"
+      }
+    },
+    {
+      "scope": "markup.heading.setext",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#268BD2"
+      }
+    }
+  ],
+  "type": "dark"
+}
+"""

--- a/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Parser.wasmJs.kt
+++ b/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Parser.wasmJs.kt
@@ -1,6 +1,105 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package dev.bnorm.storyboard
 
+import androidx.collection.mutableScatterMapOf
+import dev.bnorm.storyboard.ShikiCore.createHighlighterCoreSync
+import dev.bnorm.storyboard.ShikiEngine.createJavaScriptRegexEngine
+
+// Be very careful to **only** use APIs from `shiki-core`.
+
+internal val HIGHLIGHTERS = mutableScatterMapOf<Language, HighlighterCore>()
+
+// Use the browser's Regex engine.
+internal val ENGINE = createJavaScriptRegexEngine()
+
 actual fun parse(code: String, language: Language): List<Token> {
-    // Use something like `Shiki` to complete the implementation here.
-    TODO("WASM Support is not complete.")
+    return when (language) {
+        is Custom -> language.parser.parse(code)
+        else -> {
+            val name = requireNotNull(LANGUAGE_NAMES[language]) {
+                "Unable to find name for $language. Did you register it?"
+            }
+            val options = codeToTokenOptions(name = name.toJsString())
+            val highlighterCore = getOrCreateHighlighter(language)
+            val result = highlighterCore.codeToTokens(code = code.toJsString(), options = options)
+            val themedTokens: JsArray<JsArray<ThemedToken>> = result.tokens
+            val tokens = mutableListOf<Token>()
+            for (i in 0 until themedTokens.length) {
+                val row = themedTokens[i]!!
+                if (row.length <= 0) {
+                    // ShikiJs does not emit tokens for pure whitespace or empty lines.
+                    // To preserve compat and to render the correct code in slides we create a synthetic token.
+                    // This is what T4ME does.
+                    tokens += Token(
+                        content = "",
+                        scope = language.scopeName(),
+                        depth = 1,
+                        lineNumber = i,
+                        startIndex = 0,
+                        endIndex = 0,
+                        language = language,
+                        allScopes = listOf(language.scopeName())
+                    )
+                } else {
+                    for (j in 0 until row.length) {
+                        val themedToken = row[j]!!
+                        val token = themedToken.asToken(language, lineNumber = i)
+                        tokens += token
+                    }
+                }
+            }
+            tokens
+        }
+    }
+}
+
+private fun ThemedToken.asToken(language: Language, lineNumber: Int): Token {
+    val allScopes = mutableSetOf<String>()
+    val explanation = explanation
+    if (explanation != null) {
+        for (i in 0 until explanation.length) {
+            val scopes = explanation[i]!!.scopes
+            for (j in 0 until scopes.length) {
+                val scope = scopes[j]
+                if (scope != null) {
+                    allScopes += scope.scopeName.toString()
+                }
+            }
+        }
+    }
+    val token = Token(
+        content = content.toString(),
+        scope = allScopes.last(),
+        depth = allScopes.size,
+        language = language,
+        allScopes = allScopes.toList(),
+        lineNumber = lineNumber,
+        startIndex = offset.toInt(),
+        // We don't really use endIndex for anything. So it's okay.
+        endIndex = offset.toInt() + content.toString().length,
+    )
+    return token
+}
+
+// Helpers
+private fun highlighterOptions(
+    grammar: JsAny,
+    theme: JsAny = THEME,
+    engine: RegexEngine = ENGINE
+): HighlighterCoreOptions = js("({ langs: [grammar], themes: [theme], engine: engine })")
+
+private fun codeToTokenOptions(
+    name: JsString,
+    theme: JsString = THEME_NAME.toJsString()
+): CodeToTokensOptions = js("({ lang: name, theme: theme, includeExplanation: 'scopeName' })")
+
+internal fun getOrCreateHighlighter(language: Language): HighlighterCore {
+    return HIGHLIGHTERS.getOrPut(language) {
+        val grammar = requireNotNull(LANGUAGE_REGISTRY[language]) {
+            "Unable to find language $language. Did you register it?"
+        }
+        val options = highlighterOptions(grammar)
+        createHighlighterCoreSync(options = options)
+    }
 }

--- a/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Parser.wasmJs.kt
+++ b/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Parser.wasmJs.kt
@@ -1,0 +1,6 @@
+package dev.bnorm.storyboard
+
+actual fun parse(code: String, language: Language): List<Token> {
+    // Use something like `Shiki` to complete the implementation here.
+    TODO("WASM Support is not complete.")
+}

--- a/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Shiki.kt
+++ b/storyboard-warp/src/wasmJsMain/kotlin/dev/bnorm/storyboard/Shiki.kt
@@ -1,0 +1,85 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package dev.bnorm.storyboard
+
+@JsModule("shiki/engine/javascript")
+external object ShikiEngine {
+    fun createJavaScriptRegexEngine(
+        options: JavaScriptRegexEngineOptions = definedExternally
+    ): RegexEngine
+}
+
+external interface RegexEngine : JsAny
+
+external interface JavaScriptRegexEngineOptions : JsAny {
+    var target: JsString?
+    var forEach: JsAny?
+}
+
+@JsModule("shiki/core")
+external object ShikiCore {
+    fun createHighlighterCoreSync(
+        options: HighlighterCoreOptions
+    ): HighlighterCore
+}
+
+external interface HighlighterCore : JsAny {
+    fun codeToTokens(
+        code: JsString,
+        options: CodeToTokensOptions
+    ): TokensResult
+
+    fun codeToHtml(
+        code: JsString,
+        options: CodeToHtmlOptions
+    ): JsString
+
+    fun loadTheme(vararg themes: JsAny)
+    fun loadLanguage(vararg langs: JsAny)
+    fun getLoadedThemes(): JsArray<JsString>
+    fun getLoadedLanguages(): JsArray<JsString>
+    fun dispose()
+}
+
+external interface ThemedToken : JsAny {
+    var content: JsString
+    var offset: JsNumber
+    var color: JsString?
+    var bgColor: JsString?
+    var fontStyle: JsNumber?
+    var explanation: JsArray<ThemedTokenScopeExplanation>?
+}
+
+external interface ThemedTokenScopeExplanation : JsAny {
+    /** The full resolved scope stack path */
+    var scopes: JsArray<Scope>
+}
+
+external interface Scope : JsAny {
+    var scopeName: JsString
+}
+
+external interface TokensResult : JsAny {
+    var tokens: JsArray<JsArray<ThemedToken>>
+    var fg: JsString?
+    var bg: JsString?
+    var themeName: JsString?
+    var rootStyle: JsString?
+}
+
+external interface HighlighterCoreOptions : JsAny {
+    var themes: JsArray<JsAny>
+    var langs: JsArray<JsAny>
+    var engine: RegexEngine
+}
+
+external interface CodeToTokensOptions : JsAny {
+    var lang: JsString
+    var theme: JsAny // Can be a JsString (theme name) or theme object
+    var includeExplanation: JsAny?
+}
+
+external interface CodeToHtmlOptions : JsAny {
+    var lang: JsString
+    var theme: JsAny
+}

--- a/storyboard-warp/src/wasmJsTest/kotlin/dev/bnorm/storyboard/ParserTest.kt
+++ b/storyboard-warp/src/wasmJsTest/kotlin/dev/bnorm/storyboard/ParserTest.kt
@@ -1,0 +1,32 @@
+package dev.bnorm.storyboard
+
+import kotlin.test.Test
+
+class ParserTest {
+    @Test
+    fun testParseTokens() {
+        val tokens = parse(
+            code = """
+                val x = 10
+                println(x)
+            """.trimIndent(),
+            language = Kotlin
+        )
+        println(tokens)
+    }
+
+    @Test
+    fun testParseTokensWithEmptyLines() {
+        val tokens = parse(
+            code = """
+              import androidx.tracing.Tracer
+
+              fun main() {
+
+              }
+            """.trimIndent(),
+            language = Kotlin
+        )
+        tokens.forEach { println(it) }
+    }
+}


### PR DESCRIPTION
**This is a stacked PR**. (on top of https://github.com/bnorm/storyboard/pull/43)

**What this is**

`storyboard-warp` has a WASM implementation that _just_ works.

- This brings the `wasmJs` implementation of the `Parser`. 
- The `wasmJs` implementation uses `shiki/core`. We don't use anything bundled automatically.
- Instead we only use APIs in `core`, and `engine`. That way we avoid pulling in unnecessary dependencies.
- Minor changes to `DiffLists` to remove the suppress `UnsafeCast`s.
- Pleasantly surprised by how nice the WASM tooling has been mostly.